### PR TITLE
Add day-phase villager movement and integrate simulation

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -17,15 +17,15 @@ Créer une simulation de village modulaire, configurable et réaliste, avec des 
 - [x] Implémenter une logique d'occupation avec :
   - 10% de chance d'être "idle".
   - 90% de chance de se déplacer vers un bâtiment.
-- [ ] S'assurer que les occupations sont choisies parmi les bâtiments disponibles dans la simulation.
-- [ ] Étendre les choix d'occupation aux phases du soir et de la nuit.
+- [x] S'assurer que les occupations sont choisies parmi les bâtiments disponibles dans la simulation.
+- [x] Étendre les choix d'occupation aux phases du soir et de la nuit.
 
 ### Étape 3 : Système de déplacement
 - [x] Implémenter un système de déplacement simplifié :
   - Les villageois se déplacent en ligne droite vers leur cible.
 - [ ] Gérer les collisions et les priorités entre villageois.
-- [ ] Corriger l'appel à `move_towards_target` dans `Simulation.run_tick`.
-- [ ] Intégrer la classe `Simulation` dans `main.py` pour mettre à jour les déplacements.
+- [x] Corriger l'appel à `move_towards_target` dans `Simulation.run_tick`.
+- [x] Intégrer la classe `Simulation` dans `main.py` pour mettre à jour les déplacements.
 - [ ] Utiliser `KMH_TO_PIXELS_PER_TICK` pour la vitesse des personnages ou supprimer la constante si elle est inutile.
 
 ### Étape 4 : Gestion des bâtiments et affichage

--- a/character.py
+++ b/character.py
@@ -1,26 +1,36 @@
 import random
 
+
 class Character:
     def __init__(self, name, position):
         self.name = name
-        self.position = position  # (x, y)
-        self.state = "idle"  # travail ou repos
-        self.target = None
+        self.position = position  # Position actuelle (x, y)
+        self.home_position = position  # Domicile
+        self.state = "idle"
+        self.target = position
+        self.last_phase = None
 
     def choose_action(self, day_phase, world):
-        """Choisit une action selon la phase de la journée."""
-        if day_phase == "matin" or day_phase == "midi":
-            if random.random() < 0.5:  # 50% de chance de rester immobile
+        """Choisit une action lorsque la phase de la journée change."""
+        if day_phase == self.last_phase:
+            return
+
+        self.last_phase = day_phase
+
+        if day_phase in ("matin", "midi"):
+            if not world.buildings or random.random() < 0.5:
                 self.target = self.position
                 self.state = "Rester immobile"
             else:
-                if world.buildings:
-                    target_building = random.choice(world.buildings)
-                    self.target = target_building.position
-                    self.state = f"Aller vers {target_building.name}"
-                else:
-                    self.target = self.position
-                    self.state = "Rester immobile"
+                target_building = random.choice(world.buildings)
+                self.target = target_building.position
+                self.state = f"Aller vers {target_building.name}"
+        elif day_phase == "soir":
+            self.target = self.home_position
+            self.state = "Retourner à la maison"
+        elif day_phase == "nuit":
+            self.target = self.home_position
+            self.state = "Dormir"
 
     def move_towards_target(self):
         """Déplace le personnage directement vers la cible en ligne droite."""
@@ -30,15 +40,13 @@ class Character:
         x, y = self.position
         tx, ty = self.target
 
-        # Calculer le déplacement en ligne droite
         dx = 1 if tx > x else -1 if tx < x else 0
         dy = 1 if ty > y else -1 if ty < y else 0
 
-        # Mettre à jour la position directement
         self.position = (x + dx, y + dy)
 
     def perform_daily_action(self, day_phase, world):
         """Effectue une action en fonction de la phase de la journée."""
         self.choose_action(day_phase, world)
-        if self.position != self.target:
-            self.move_towards_target()
+        self.move_towards_target()
+

--- a/main.py
+++ b/main.py
@@ -50,6 +50,9 @@ def main():
         for i in range(NUM_VILLAGERS)
     ]
 
+    # Initialisation de la simulation
+    simulation = Simulation(world, villagers)
+
     # Affichage des bâtiments avec leurs noms
     font = pygame.font.SysFont(None, 32)
     for b in world.buildings:
@@ -67,6 +70,8 @@ def main():
         for event in pygame.event.get():
             if event.type == pygame.QUIT:
                 running = False
+
+        simulation.run_tick()
 
         # Affichage
         screen.fill((50, 150, 50))

--- a/simulation.py
+++ b/simulation.py
@@ -21,5 +21,4 @@ class Simulation:
         self.time = self.tick * 0.1  # Met à jour l'heure de la simulation
         self.update_phase()
         for char in self.characters:
-            char.choose_action(self.day_phase, self.world)
-            char.move_towards_target(self.world)
+            char.perform_daily_action(self.day_phase, self.world)


### PR DESCRIPTION
## Summary
- Add home position and phase-aware behaviour so villagers travel to buildings, return home at night and only change goals when the day phase changes
- Run characters through Simulation each frame to update positions
- Mark corresponding TODO items as completed

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890dff365708330ba165b9946416291