### PR TITLE
Add dynamic occupations and resource production system

### DIFF
--- a/character.py
+++ b/character.py
@@ -59,6 +59,10 @@ class Character:
         # Taille différente selon l'âge (enfant/adulte)
         self.radius = CHILD_RADIUS if role == "enfant" else ADULT_RADIUS
 
+        # Occupation courante (type de bâtiment) et couleur associée
+        self.current_occupation = None
+        self.occupation_color = (0, 0, 0)
+
     def choose_action(self, day_phase, world):
         """Choisit une action lorsque la phase de la journée change."""
         if day_phase == self.last_phase:

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ import pygame
 from settings import (
     SCREEN_WIDTH,
     SCREEN_HEIGHT,
+    MENU_WIDTH,
     NUM_VILLAGERS,
     TICK_DURATION,
     MOVEMENT_RANDOM_FACTOR,
@@ -28,7 +29,7 @@ logging.info("Simulation démarrée.")
 
 def main():
     pygame.init()
-    screen = pygame.display.set_mode((SCREEN_WIDTH, SCREEN_HEIGHT))
+    screen = pygame.display.set_mode((SCREEN_WIDTH + MENU_WIDTH, SCREEN_HEIGHT))
     pygame.display.set_caption("Village Simulator")
 
     # Initialisation du monde et des bâtiments
@@ -39,11 +40,10 @@ def main():
         building_configs = {b["type"]: b for b in json.load(f)}
 
     # Chargement des données de la carte depuis le fichier JSON
-    appearance = {}
     with open("map.json", "r", encoding="utf-8") as f:
         map_data = json.load(f)
         for item in map_data:
-            cfg = building_configs.get(item["type"], {})
+            cfg = building_configs.get(item["type"] , {})
             color = tuple(item.get("color", cfg.get("color", (100, 100, 100))))
             size = tuple(item.get("size", cfg.get("size", (40, 40))))
             production = item.get("production", cfg.get("production"))
@@ -53,9 +53,9 @@ def main():
                 size,
                 type=item["type"],
                 production=production,
+                color=color,
             )
             world.add_building(building)
-            appearance[building] = color
 
     # Vérification du nombre de bâtiments
     if len(world.buildings) != len(map_data):
@@ -93,7 +93,7 @@ def main():
 
     # Initialisation de la simulation et du rendu
     simulation = Simulation(world, villagers)
-    renderer = Renderer(screen, world, appearance)
+    renderer = Renderer(screen, world)
 
     # Simulation loop
     clock = pygame.time.Clock()

--- a/settings.py
+++ b/settings.py
@@ -1,20 +1,45 @@
 """Configuration options for the simulator."""
 
-# Paramètres globaux
-# next step: Définir résolution écran, tick duration, nombre de villageois
+from dataclasses import dataclass
 
-SCREEN_WIDTH = 1200
-SCREEN_HEIGHT = 720
-TICK_DURATION = 50  # ms (pour accélérer la journée à 3 minutes)
-NUM_VILLAGERS = 30
 
-# Vitesse de déplacement des villageois (en pixels par tick, calculée pour 5 km/h)
-KMH_TO_PIXELS_PER_TICK = (5 * 1000 / 60 / 60) * (SCREEN_WIDTH / 500)
+@dataclass
+class Config:
+    # Dimensions du monde (zone jouable)
+    screen_width: int = 1200
+    screen_height: int = 720
+    # Largeur du panneau latéral d'information
+    menu_width: int = 200
 
-# Facteurs de déplacement
-MOVEMENT_RANDOM_FACTOR = 10  # Intensité de l'aléatoire lors des déplacements
-NEAR_DESTINATION_RADIUS = 30  # Rayon (en px) de déplacement autour de la cible
+    # Durée d'un tick et nombre de villageois
+    tick_duration: int = 50  # ms (pour accélérer la journée à 3 minutes)
+    num_villagers: int = 30
 
-# Tailles des personnages selon l'âge
-ADULT_RADIUS = 15
-CHILD_RADIUS = 6
+    # Vitesse de déplacement (5 km/h)
+    kmh_to_pixels_per_tick: float = 0.0
+
+    # Facteurs de déplacement
+    movement_random_factor: int = 10  # Intensité de l'aléatoire lors des déplacements
+    near_destination_radius: int = 30  # Rayon (en px) de déplacement autour de la cible
+
+    # Tailles des personnages
+    adult_radius: int = 15
+    child_radius: int = 6
+
+    def __post_init__(self):
+        self.kmh_to_pixels_per_tick = (5 * 1000 / 60 / 60) * (self.screen_width / 500)
+
+
+config = Config()
+
+# Compatibilité ascendante : export des constantes
+SCREEN_WIDTH = config.screen_width
+SCREEN_HEIGHT = config.screen_height
+MENU_WIDTH = config.menu_width
+TICK_DURATION = config.tick_duration
+NUM_VILLAGERS = config.num_villagers
+KMH_TO_PIXELS_PER_TICK = config.kmh_to_pixels_per_tick
+MOVEMENT_RANDOM_FACTOR = config.movement_random_factor
+NEAR_DESTINATION_RADIUS = config.near_destination_radius
+ADULT_RADIUS = config.adult_radius
+CHILD_RADIUS = config.child_radius

--- a/simulation.py
+++ b/simulation.py
@@ -34,7 +34,8 @@ class Simulation:
         self.time_of_day = ((self.tick % total_ticks) / total_ticks * 24 + 6) % 24
         phase_changed = self.update_phase()
         for building in self.world.buildings:
-            building.produce()
+            building.occupants = []
+
         occupied_positions = []
         for char in self.characters:
             previous_position = char.position
@@ -48,6 +49,18 @@ class Simulation:
                     break
 
             occupied_positions.append(char.position)
+
+            char.current_occupation = None
+            char.occupation_color = (0, 0, 0)
+            for building in self.world.buildings:
+                if building.contains(char.position):
+                    building.occupants.append(char)
+                    char.current_occupation = building.type
+                    char.occupation_color = building.color
+                    break
+
+        for building in self.world.buildings:
+            building.produce(len(building.occupants))
 
         if phase_changed:
             logging.info(f"===== {self.day_phase.upper()} {int(self.time_of_day):02d}h =====")

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -77,10 +77,11 @@ def test_children_stay_at_school_at_lunch():
     assert child.anchor == school.center
 
 
-def test_building_produces_resources():
-    world = World(100, 100)
-    farm = Building("Ferme", (0, 0), production={"nourriture": 2})
+def test_building_produces_resources_with_occupants():
+    world = World(200, 200)
+    farm = Building("Ferme", (0, 0), size=(100, 100), type="ferme", production={"nourriture": 2})
     world.add_building(farm)
-    sim = Simulation(world, [])
+    villager = Character("Bob", farm.center, role="fermier", gender="homme", random_factor=0)
+    sim = Simulation(world, [villager])
     sim.run_tick()
     assert farm.inventory["nourriture"] == 2

--- a/world.py
+++ b/world.py
@@ -5,22 +5,38 @@ This module purposely avoids any rendering code; drawing is delegated to the
 
 # Classe Building, représentant un bâtiment logique sans rendu
 class Building:
-    def __init__(self, name, position, size=(30, 30), type="maison", production=None):
+    def __init__(
+        self,
+        name,
+        position,
+        size=(30, 30),
+        type="maison",
+        production=None,
+        color=(100, 100, 100),
+    ):
         self.name = name
         self.position = position  # (x, y)
         self.size = size  # (w, h)
         self.type = type  # maison, ferme, forge, taverne, etc.
         self.production = production or {}
         self.inventory = {res: 0 for res in self.production}
+        self.color = color
+        self.occupants = []
         # Centre du bâtiment, utilisé comme point de rassemblement
         self.center = (
             position[0] + size[0] / 2,
             position[1] + size[1] / 2,
         )
 
-    def produce(self):
+    def contains(self, position):
+        x, y = position
+        bx, by = self.position
+        bw, bh = self.size
+        return bx <= x <= bx + bw and by <= y <= by + bh
+
+    def produce(self, occupants=0):
         for res, rate in self.production.items():
-            self.inventory[res] = self.inventory.get(res, 0) + rate
+            self.inventory[res] = self.inventory.get(res, 0) + rate * occupants
 
 class InteractiveObject:
     def __init__(self, name, position, type):


### PR DESCRIPTION
## Summary
- support per-building colors and occupant-based resource output
- simplify settings with dataclass and right-side info menu
- track villager occupations with colored borders and sidebar display

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68912b06f9d48330b35b5d3a0968bbe7