### PR TITLE
feat: enrich character display and activity scheduling

### DIFF
--- a/character.py
+++ b/character.py
@@ -57,6 +57,8 @@ class Character:
         self.role = role
         self.role_color = tuple(r_info["color"])
         self.role_building = r_info.get("building")
+        # Libellé court (1-2 lettres) pour afficher le rôle dans le rendu
+        self.role_label = "".join(c for c in role if c.isalpha())[:2].upper()
 
         # Taille différente selon l'âge (enfant/adulte)
         self.radius = CHILD_RADIUS if role == "enfant" else ADULT_RADIUS
@@ -67,6 +69,9 @@ class Character:
         self.money = 0
         self.inventory = {}
         self.work_ratio = work_ratio
+        # Compteurs de temps passés au travail ou en activité libre
+        self.work_time = 0
+        self.leisure_time = 0
 
     def choose_action(self, day_phase, world):
         """Choisit une action lorsque la phase de la journée change."""
@@ -77,7 +82,10 @@ class Character:
 
         if day_phase in ("matin", "apres_midi"):
             target_building = None
-            go_work = random.random() < self.work_ratio or self.role == "enfant"
+            # Décide d'aller travailler selon le ratio temps de travail/temps libre
+            total = self.work_time + self.leisure_time
+            current_ratio = self.work_time / total if total else 0
+            go_work = current_ratio < self.work_ratio or self.role == "enfant"
             if go_work and self.role_building:
                 for b in world.buildings:
                     if b.type == self.role_building:
@@ -185,4 +193,9 @@ class Character:
         self.choose_action(day_phase, world)
         self.move_towards_target()
         self.attempt_purchase(world)
+
+    def reset_daily_counters(self):
+        """Réinitialise les compteurs de temps en début de journée."""
+        self.work_time = 0
+        self.leisure_time = 0
 

--- a/renderer.py
+++ b/renderer.py
@@ -34,10 +34,17 @@ class Renderer:
         for villager in villagers:
             vx, vy = villager.position
             radius = villager.radius
-            pygame.draw.circle(self.screen, villager.role_color, (int(vx), int(vy)), radius)
+            # Couleur centrale représentant le genre
+            pygame.draw.circle(self.screen, villager.gender_color, (int(vx), int(vy)), radius)
+            # Anneau extérieur représentant l'occupation courante
             pygame.draw.circle(
                 self.screen, villager.occupation_color, (int(vx), int(vy)), radius, 3
             )
+            # Lettres du rôle au centre
+            role_text = self.font.render(villager.role_label, True, (0, 0, 0))
+            role_rect = role_text.get_rect(center=(int(vx), int(vy)))
+            self.screen.blit(role_text, role_rect)
+            # Nom au-dessus du personnage
             name_text = self.font.render(villager.name, True, (255, 255, 255))
             text_rect = name_text.get_rect(center=(int(vx), int(vy) - radius - 5))
             self.screen.blit(name_text, text_rect)
@@ -72,12 +79,17 @@ class Renderer:
             info_y += 20
             sel_lines = [
                 f"Nom: {selected.name}",
+                f"Genre: {selected.gender}",
                 f"Rôle: {selected.role}",
                 f"Argent: {selected.money}",
             ]
             if selected.inventory:
                 inv = ", ".join(f"{k}:{v}" for k, v in selected.inventory.items())
                 sel_lines.append(f"Inventaire: {inv}")
+            if selected.current_occupation:
+                sel_lines.append(f"Occupation: {selected.current_occupation}")
+            else:
+                sel_lines.append(f"Destination: {selected.state}")
             for line in sel_lines:
                 text = self.font.render(line, True, (0, 0, 0))
                 self.screen.blit(text, (SCREEN_WIDTH + 10, info_y))

--- a/simulation.py
+++ b/simulation.py
@@ -32,6 +32,10 @@ class Simulation:
         """Exécute un tick de la simulation."""
         self.tick += 1
         total_ticks = sum(self.phase_durations)
+        # Début d'une nouvelle journée : remise à zéro des compteurs d'occupation
+        if (self.tick - 1) % total_ticks == 0:
+            for char in self.characters:
+                char.reset_daily_counters()
         self.time_of_day = ((self.tick % total_ticks) / total_ticks * 24 + 6) % 24
         phase_changed = self.update_phase()
         for building in self.world.buildings:
@@ -63,6 +67,12 @@ class Simulation:
                     ):
                         pay_salary(char, building)
                     break
+            # Mise à jour des compteurs d'occupation pendant les phases actives
+            if self.day_phase in ("matin", "apres_midi"):
+                if char.current_occupation == char.role_building:
+                    char.work_time += 1
+                else:
+                    char.leisure_time += 1
 
         for building in self.world.buildings:
             building.produce(len(building.occupants))

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -57,6 +57,18 @@ def test_role_goes_to_associated_building():
     assert "Forge" in smith.state
 
 
+def test_low_work_ratio_avoids_work():
+    world = World(100, 100)
+    forge = Building("Forge", (20, 20), size=(10, 10), type="forge")
+    tavern = Building("Taverne", (40, 40), size=(10, 10), type="taverne")
+    world.add_building(forge)
+    world.add_building(tavern)
+    smith = Character("Lazy", (0, 0), role="forgeron", gender="homme", random_factor=0, work_ratio=0.0)
+    smith.perform_daily_action("matin", world)
+    # Avec un ratio nul, le personnage ne doit pas viser son lieu de travail
+    assert smith.anchor != forge.center
+
+
 def test_adult_goes_to_restaurant_at_lunch():
     world = World(200, 200)
     r1 = Building("R1", (10, 10), size=(10, 10), type="restaurant")


### PR DESCRIPTION
## Summary
- color characters by gender and current occupation
- show role letters and detailed info in sidebar
- schedule work vs leisure time based on ratio

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689139bce37083309cecd593f79a82ba