### PR TITLE
Affiche la fatigue du personnage sélectionné

### DIFF
--- a/renderer.py
+++ b/renderer.py
@@ -5,7 +5,7 @@ Static elements like buildings are pre-rendered on a background surface to
 minimise per-frame work."""
 
 import pygame
-from settings import SCREEN_WIDTH, MENU_WIDTH
+from settings import SCREEN_WIDTH, MENU_WIDTH, FATIGUE_MAX
 
 
 class Renderer:
@@ -27,6 +27,24 @@ class Renderer:
             name_text = self.font.render(building.name, True, (0, 0, 0))
             text_rect = name_text.get_rect(center=(bx + bw / 2, by + bh / 2))
             self.background.blit(name_text, text_rect)
+
+    def _selected_info_lines(self, selected):
+        """Return formatted info lines for a selected villager."""
+        lines = [
+            f"Nom: {selected.name}",
+            f"Genre: {selected.gender}",
+            f"Rôle: {selected.role}",
+            f"Argent: {selected.money}",
+            f"Fatigue: {selected.fatigue}/{FATIGUE_MAX}",
+        ]
+        if selected.inventory:
+            inv = ", ".join(f"{k}:{v}" for k, v in selected.inventory.items())
+            lines.append(f"Inventaire: {inv}")
+        if selected.current_occupation:
+            lines.append(f"Occupation: {selected.current_occupation}")
+        else:
+            lines.append(f"Destination: {selected.state}")
+        return lines
 
     def draw(self, villagers, time_of_day, selected=None, paused=False):
         """Render villagers and UI on top of the static background."""
@@ -77,20 +95,7 @@ class Renderer:
 
         if selected:
             info_y += 20
-            sel_lines = [
-                f"Nom: {selected.name}",
-                f"Genre: {selected.gender}",
-                f"Rôle: {selected.role}",
-                f"Argent: {selected.money}",
-            ]
-            if selected.inventory:
-                inv = ", ".join(f"{k}:{v}" for k, v in selected.inventory.items())
-                sel_lines.append(f"Inventaire: {inv}")
-            if selected.current_occupation:
-                sel_lines.append(f"Occupation: {selected.current_occupation}")
-            else:
-                sel_lines.append(f"Destination: {selected.state}")
-            for line in sel_lines:
+            for line in self._selected_info_lines(selected):
                 text = self.font.render(line, True, (0, 0, 0))
                 self.screen.blit(text, (SCREEN_WIDTH + 10, info_y))
                 info_y += 15

--- a/tests/test_renderer_display.py
+++ b/tests/test_renderer_display.py
@@ -1,0 +1,21 @@
+import os
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+import pygame
+
+from renderer import Renderer
+from world import World
+from character import Character
+
+
+def test_selected_info_includes_fatigue():
+    pygame.init()
+    try:
+        screen = pygame.Surface((100, 100))
+        world = World(100, 100)
+        renderer = Renderer(screen, world)
+        char = Character("Bob", (10, 10), role="forgeron", gender="homme")
+        char.fatigue = 42
+        lines = renderer._selected_info_lines(char)
+        assert any("Fatigue" in line and "42" in line for line in lines)
+    finally:
+        pygame.quit()


### PR DESCRIPTION
## Summary
- Affiche le niveau de fatigue dans la fiche d'un personnage sélectionné.
- Ajoute un test vérifiant la présence de cette information.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892364c74d48330b74d43b3909f0914