### PR TITLE
Add random seed configuration for determinism

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3,7 +3,7 @@
 ## Stabilisation
 - [x] Empêcher les personnages de quitter le périmètre de leur bâtiment lorsqu'ils sont immobiles.
 - [x] Ajouter des tests unitaires pour valider les déplacements et le changement de phase.
-- [ ] Introduire un système de seed pour rendre les tests déterministes.
+ - [x] Introduire un système de seed pour rendre les tests déterministes.
 - [ ] Vérifier la stabilité après plusieurs jours de simulation.
 - [ ] Surveiller la dérive numérique en recentrant périodiquement les positions.
 

--- a/settings.py
+++ b/settings.py
@@ -1,6 +1,7 @@
 """Configuration options for the simulator."""
 
 from dataclasses import dataclass
+import random
 
 
 @dataclass
@@ -17,6 +18,9 @@ class Config:
 
     # Vitesse de déplacement (5 km/h)
     kmh_to_pixels_per_tick: float = 0.0
+
+    # Graine aléatoire pour rendre la simulation déterministe
+    random_seed: int | None = 0
 
     # Facteurs de déplacement
     movement_random_factor: int = 2  # Intensité de l'aléatoire lors des déplacements
@@ -36,6 +40,8 @@ class Config:
 
     def __post_init__(self):
         self.kmh_to_pixels_per_tick = (5 * 1000 / 60 / 60) * (self.screen_width / 400)
+        if self.random_seed is not None:
+            random.seed(self.random_seed)
 
 
 config = Config()
@@ -52,6 +58,7 @@ NEAR_DESTINATION_RADIUS = config.near_destination_radius
 ADULT_RADIUS = config.adult_radius
 CHILD_RADIUS = config.child_radius
 WORK_TIME_RATIO = config.work_time_ratio
+RANDOM_SEED = config.random_seed
 FATIGUE_MAX = config.fatigue_max
 FATIGUE_WORK_RATE = config.fatigue_work_rate
 FATIGUE_IDLE_RATE = config.fatigue_idle_rate


### PR DESCRIPTION
## Summary
- allow setting a random seed via configuration to make runs reproducible
- mark seed support in TODO list

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68925369f42c83309b849d4170b860c6