### PR TITLE
feat: add tree viewer and plugin loading

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -6,6 +6,8 @@ Cette documentation décrit en détail le fonctionnement du programme de simulat
 
 Le simulateur est organisé autour d'une structure d'objets en arbre (`SimNode`) qui relie les différents éléments logiques : monde, bâtiments et personnages. La boucle de simulation met à jour ces objets à chaque tick, tandis que le module `renderer` se charge de l'affichage Pygame.
 
+Un registre de plugins (`core.plugins`) permet de déclarer dynamiquement de nouveaux types de nœuds. Les modules listés dans `settings.PLUGINS` sont importés au démarrage.
+
 ## Principaux modules
 
 ### `main.py`
@@ -71,10 +73,15 @@ Les bâtiments producteurs génèrent des ressources stockées dans leur inventa
 
 Le répertoire `tests/` contient des tests Pytest validant notamment la gestion de la fatigue, le fonctionnement du renderer et la progression de la simulation.
 
+## Outils de développement
+
+- `python main.py --tree` ouvre un visualiseur interactif (`ui.tree_viewer`) montrant la structure de l'arbre `SimNode`.
+
 ## Utilisation
 
 1. Installer les dépendances : `pip install -r requirements.txt`
 2. Lancer la simulation : `python main.py`
+   - ou afficher l'arbre des objets : `python main.py --tree`
 3. Contrôles principaux :
    - `P` pour mettre en pause/reprendre
    - cliquer sur un personnage pour afficher ses détails

--- a/README.md
+++ b/README.md
@@ -16,12 +16,16 @@ Une simulation minimaliste d'un village en 2D. Les habitants se déplacent entre
 - Possibilité de mettre la simulation en pause (`P`) et d'inspecter un personnage en cliquant dessus.
 - Système économique basique : les travailleurs reçoivent un salaire, peuvent dépenser leur argent et transporter des ressources.
 - La proportion de temps consacrée au travail est configurable (`work_time_ratio`).
+- Architecture en arbre (`SimNode`) permettant d'ajouter facilement de nouveaux objets ou règles.
+- Support de plugins déclarés dans `settings.py`.
+- Visualisation de la structure via `python main.py --tree`.
 
 ## Lancer la simulation
 
 ```bash
 pip install -r requirements.txt
-python main.py
+python main.py            # lance la simulation
+python main.py --tree     # affiche l'arbre des objets
 ```
 
 ## Contrôles

--- a/TODO.md
+++ b/TODO.md
@@ -31,6 +31,8 @@
 - Profiler la boucle de simulation pour identifier les goulots d'étranglement.
 - Mettre en place une intégration continue pour exécuter les tests.
 - Exporter des logs pour analyser les comportements anormaux.
+- [x] Visualiseur d'arbre interactif pour inspecter la simulation (`--tree`).
+- [x] Chargement optionnel de plugins via `settings.PLUGINS`.
 
 ## Brainstorm
 - Lier un agent LLM à chaque personnage pour un comportement émergent.

--- a/core/plugins.py
+++ b/core/plugins.py
@@ -1,5 +1,8 @@
 """Simple plugin registry for simulation extensions."""
 
+from importlib import import_module
+import logging
+
 _registry = {}
 
 
@@ -18,6 +21,11 @@ def load_plugins(module_names):
     """Dynamically import a list of plugin modules.
 
     Each module is expected to call :func:`register_node_type` during import.
+    Any import error is logged but does not stop the program.
     """
     for mod in module_names:
-        __import__(mod)
+        try:
+            import_module(mod)
+            logging.info("Plugin loaded: %s", mod)
+        except Exception as exc:  # pragma: no cover - defensive
+            logging.error("Failed to load plugin %s: %s", mod, exc)

--- a/main.py
+++ b/main.py
@@ -1,6 +1,12 @@
 """Point d'entrée de la simulation et configuration initiale."""
 
+import argparse
+import json
+import logging
+import random  # Importation de random pour le choix aléatoire
+
 import pygame
+
 from settings import (
     SCREEN_WIDTH,
     SCREEN_HEIGHT,
@@ -8,29 +14,35 @@ from settings import (
     NUM_VILLAGERS,
     TICK_DURATION,
     MOVEMENT_RANDOM_FACTOR,
+    PLUGINS,
 )
 from nodes.character import Character
 from nodes.world import World, Building
 from core.simulation import Simulation
+from core.plugins import load_plugins
 from ui.renderer import Renderer
-import json
-import logging
-import random  # Importation de random pour le choix aléatoire
 
 # Configuration du logging
 logging.basicConfig(
-    filename='simulation.log',
-    filemode='w',
+    filename="simulation.log",
+    filemode="w",
     level=logging.INFO,
-    format='%(asctime)s - %(levelname)s - %(message)s',
-    encoding='utf-8'
+    format="%(asctime)s - %(levelname)s - %(message)s",
+    encoding="utf-8",
 )
 logging.info("Simulation démarrée.")
 
+
 def main():
-    pygame.init()
-    screen = pygame.display.set_mode((SCREEN_WIDTH + MENU_WIDTH, SCREEN_HEIGHT))
-    pygame.display.set_caption("Village Simulator")
+    parser = argparse.ArgumentParser(description="Village Simulator")
+    parser.add_argument(
+        "--tree",
+        action="store_true",
+        help="Afficher la structure de l'arbre de simulation sans lancer la boucle principale",
+    )
+    args = parser.parse_args()
+
+    load_plugins(PLUGINS)
 
     # Initialisation du monde et des bâtiments
     world = World(SCREEN_WIDTH, SCREEN_HEIGHT)
@@ -91,8 +103,18 @@ def main():
             )
         )
 
-    # Initialisation de la simulation et du rendu
+    # Initialisation de la simulation
     simulation = Simulation(world, villagers)
+
+    if args.tree:
+        from ui.tree_viewer import run_viewer
+
+        run_viewer(simulation.root)
+        return
+
+    pygame.init()
+    screen = pygame.display.set_mode((SCREEN_WIDTH + MENU_WIDTH, SCREEN_HEIGHT))
+    pygame.display.set_caption("Village Simulator")
     renderer = Renderer(screen, world)
 
     # Simulation loop

--- a/settings.py
+++ b/settings.py
@@ -34,6 +34,9 @@ class Config:
     fatigue_idle_rate: int = 1
     collapse_sleep_ticks: int = 500  # 6h en supposant 2000 ticks par journée
 
+    # Liste optionnelle de modules de plugins à charger au démarrage
+    plugins: tuple[str, ...] = ()
+
     def __post_init__(self):
         self.kmh_to_pixels_per_tick = (5 * 1000 / 60 / 60) * (self.screen_width / 400)
 
@@ -56,3 +59,4 @@ FATIGUE_MAX = config.fatigue_max
 FATIGUE_WORK_RATE = config.fatigue_work_rate
 FATIGUE_IDLE_RATE = config.fatigue_idle_rate
 COLLAPSE_SLEEP_TICKS = config.collapse_sleep_ticks
+PLUGINS = config.plugins

--- a/ui/tree_viewer.py
+++ b/ui/tree_viewer.py
@@ -29,6 +29,7 @@ def draw_node(screen, node, pos, selected):
     return rect
 
 def run_viewer(root):
+    """Affiche l'arbre de nœuds `SimNode` à partir de ``root``."""
     pygame.init()
     global FONT
     FONT = pygame.font.SysFont(None, 18)


### PR DESCRIPTION
## Summary
- expose tree viewer via `--tree` flag
- support optional plugin modules at startup
- document modular architecture and update docs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893686214048330849a2d37fcb0e62f